### PR TITLE
Grid: Image field is now image.Image

### DIFF
--- a/go-image-merge.go
+++ b/go-image-merge.go
@@ -25,7 +25,7 @@ const (
 
 // Grid holds the data for each grid
 type Grid struct {
-	Image           *image.Image
+	Image           image.Image
 	ImageFilePath   string
 	BackgroundColor color.Color
 	OffsetX         int
@@ -86,7 +86,7 @@ func OptGridSizeFromNthImageSize(n int) func(*MergeImage) {
 
 func (m *MergeImage) readGridImage(grid *Grid) (image.Image, error) {
 	if grid.Image != nil {
-		return *grid.Image, nil
+		return grid.Image, nil
 	}
 
 	imgPath := grid.ImageFilePath


### PR DESCRIPTION
Hi there,
in your Grid structure, `Image` field is a pointer to interface. In my opinion it is not necessary.