### PR TITLE
Add webp support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ozankasikci/go-image-merge
 
-go 1.13
+go 1.25.0
+
+require golang.org/x/image v0.38.0

--- a/image-merge.go
+++ b/image-merge.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/image/webp"
 )
 
 // Specifies how the grid pixel size should be calculated
@@ -125,6 +127,8 @@ func (m *MergeImage) ReadImageFile(path string) (image.Image, error) {
 
 	if ext == "jpg" || ext == "jpeg" {
 		img, err = jpeg.Decode(imgFile)
+	} else if ext == "webp" {
+		img, err = webp.Decode(imgFile)
 	} else {
 		img, err = png.Decode(imgFile)
 	}


### PR DESCRIPTION
Hi @ozankasikci,

Thank you for creating this library! We've been using it with a great success to stitch aerial imagery tiles into a one larger image.

One of the modern aerial imagery services provides images in `webp` format and I thought it would be great to support it in your library - it seems to be a pretty straight forward addition.

Let me know you thoughts